### PR TITLE
✨ Feat: 회원가입 성공 / 실패 모달창 추가

### DIFF
--- a/src/pages/signup/constants/index.ts
+++ b/src/pages/signup/constants/index.ts
@@ -1,4 +1,4 @@
-const USERINPUT = {
+const USER_INPUT = {
   EMAIL: {
     NAME: 'email',
     PLACE_HOLDER: '이메일을 입력해주세요.',
@@ -44,4 +44,4 @@ const MODAL = {
   }
 };
 
-export { USERINPUT, MODAL };
+export { USER_INPUT, MODAL };

--- a/src/pages/signup/constants/index.ts
+++ b/src/pages/signup/constants/index.ts
@@ -31,4 +31,17 @@ const USERINPUT = {
   }
 };
 
-export { USERINPUT };
+const MODAL = {
+  ERROR: {
+    EMOJI: '🚨',
+    CONTENT: '이미 존재하는 이메일이에요!',
+    LABEL: '확인'
+  },
+  SUCCESS: {
+    EMOJI: '🥳',
+    CONTENT: '나르바나에 오신것을 환영해요!',
+    LABEL: '로그인하러가기'
+  }
+};
+
+export { USERINPUT, MODAL };

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -5,7 +5,7 @@ import UserInput from '@components/UserInput';
 import Alert from '@/components/Alert';
 import { isEmailOk, isNicknameOk, isPasswordOk } from './validations';
 import { signUpUser } from '@/apis/user/getUserData';
-import { USERINPUT } from './constants';
+import { USERINPUT, MODAL } from './constants';
 import {
   SignUpForm,
   ButtonContainer,
@@ -18,8 +18,9 @@ const SignUp = () => {
   const [email, setEmail] = useState<string>('');
   const [nickname, setNickname] = useState<string>('');
   const [password, setPassword] = useState<string>('');
-  const [error, setError] = useState<boolean>(false);
   const [passwordConfirm, setPasswordConfirm] = useState<string>('');
+  const [emailError, setEmailError] = useState<boolean>(false);
+  const [signupSuccess, setSignupSuccess] = useState<boolean>(false);
   const navigate = useNavigate();
   let timer = 0;
 
@@ -61,12 +62,10 @@ const SignUp = () => {
       password === passwordConfirm
     ) {
       signUpUser({ email, password, fullName: nickname })
-        .then(() => navigate('/login'))
-        // TODO: 회원가입 성공시 로그인 페이지로 이동할 수 있는 Alert
+        .then(() => setSignupSuccess(true))
         .catch((error) => {
           console.log(error);
-          setError(true);
-          // TODO: 이메일 중복 오류시 이메일 중복 오류 Alert
+          setEmailError(true);
         });
     }
 
@@ -75,10 +74,26 @@ const SignUp = () => {
 
   return (
     <SignUpContainer>
-      {error && <Alert />}
       <LogoContainer>
         <Logo />
       </LogoContainer>
+
+      {emailError && (
+        <Alert
+          emoji={MODAL.ERROR.EMOJI}
+          content={MODAL.ERROR.CONTENT}
+          buttonLabel={MODAL.ERROR.LABEL}
+        />
+      )}
+      {signupSuccess && (
+        <Alert
+          emoji={MODAL.SUCCESS.EMOJI}
+          content={MODAL.SUCCESS.CONTENT}
+          buttonLabel={MODAL.SUCCESS.LABEL}
+          nextPageLink='/login'
+        />
+      )}
+
       <SignUpForm onSubmit={handleSubmit}>
         <UserInput
           name={USERINPUT.EMAIL.NAME}

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -19,8 +19,8 @@ const SignUp = () => {
   const [nickname, setNickname] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [passwordConfirm, setPasswordConfirm] = useState<string>('');
-  const [emailError, setEmailError] = useState<boolean>(false);
-  const [signupSuccess, setSignupSuccess] = useState<boolean>(false);
+  const [emailErrorCatched, setEmailErrorCatched] = useState<boolean>(false);
+  const [signupSucceed, setSignupSucceed] = useState<boolean>(false);
   const navigate = useNavigate();
   let timer = 0;
 
@@ -62,10 +62,10 @@ const SignUp = () => {
       password === passwordConfirm
     ) {
       signUpUser({ email, password, fullName: nickname })
-        .then(() => setSignupSuccess(true))
+        .then(() => setSignupSucceed(true))
         .catch((error) => {
           console.log(error);
-          setEmailError(true);
+          setEmailErrorCatched(true);
         });
     }
 
@@ -78,14 +78,14 @@ const SignUp = () => {
         <Logo />
       </LogoContainer>
 
-      {emailError && (
+      {emailErrorCatched && (
         <Alert
           emoji={MODAL.ERROR.EMOJI}
           content={MODAL.ERROR.CONTENT}
           buttonLabel={MODAL.ERROR.LABEL}
         />
       )}
-      {signupSuccess && (
+      {signupSucceed && (
         <Alert
           emoji={MODAL.SUCCESS.EMOJI}
           content={MODAL.SUCCESS.CONTENT}

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -5,7 +5,7 @@ import UserInput from '@components/UserInput';
 import Alert from '@/components/Alert';
 import { isEmailOk, isNicknameOk, isPasswordOk } from './validations';
 import { signUpUser } from '@/apis/user/getUserData';
-import { USERINPUT, MODAL } from './constants';
+import { USER_INPUT, MODAL } from './constants';
 import {
   SignUpForm,
   ButtonContainer,
@@ -96,44 +96,44 @@ const SignUp = () => {
 
       <SignUpForm onSubmit={handleSubmit}>
         <UserInput
-          name={USERINPUT.EMAIL.NAME}
-          placeholder={USERINPUT.EMAIL.PLACE_HOLDER}
-          title={USERINPUT.EMAIL.TITLE}
+          name={USER_INPUT.EMAIL.NAME}
+          placeholder={USER_INPUT.EMAIL.PLACE_HOLDER}
+          title={USER_INPUT.EMAIL.TITLE}
           success={isEmailOk(email)}
-          errorMessage={USERINPUT.EMAIL.ERROR_MESSAGE}
-          successMessage={USERINPUT.EMAIL.SUCCESS_MESSAGE}
+          errorMessage={USER_INPUT.EMAIL.ERROR_MESSAGE}
+          successMessage={USER_INPUT.EMAIL.SUCCESS_MESSAGE}
           handleChange={handleInputChange}
           show={email.length > 0}
         />
         <UserInput
-          name={USERINPUT.NICKNAME.NAME}
-          placeholder={USERINPUT.NICKNAME.PLACE_HOLDER}
-          title={USERINPUT.NICKNAME.TITLE}
+          name={USER_INPUT.NICKNAME.NAME}
+          placeholder={USER_INPUT.NICKNAME.PLACE_HOLDER}
+          title={USER_INPUT.NICKNAME.TITLE}
           success={isNicknameOk(nickname)}
-          errorMessage={USERINPUT.NICKNAME.ERROR_MESSAGE}
-          successMessage={USERINPUT.NICKNAME.SUCCESS_MESSAGE}
+          errorMessage={USER_INPUT.NICKNAME.ERROR_MESSAGE}
+          successMessage={USER_INPUT.NICKNAME.SUCCESS_MESSAGE}
           handleChange={handleInputChange}
           show={nickname.length > 0}
         />
         <UserInput
-          name={USERINPUT.PASSWORD.NAME}
-          type={USERINPUT.PASSWORD.TYPE}
-          placeholder={USERINPUT.PASSWORD.PLACE_HOLDER}
-          title={USERINPUT.PASSWORD.TITLE}
+          name={USER_INPUT.PASSWORD.NAME}
+          type={USER_INPUT.PASSWORD.TYPE}
+          placeholder={USER_INPUT.PASSWORD.PLACE_HOLDER}
+          title={USER_INPUT.PASSWORD.TITLE}
           success={isPasswordOk(password)}
-          errorMessage={USERINPUT.PASSWORD.ERROR_MESSAGE}
-          successMessage={USERINPUT.PASSWORD.SUCCESS_MESSAGE}
+          errorMessage={USER_INPUT.PASSWORD.ERROR_MESSAGE}
+          successMessage={USER_INPUT.PASSWORD.SUCCESS_MESSAGE}
           handleChange={handleInputChange}
           show={password.length > 0}
         />
         <UserInput
-          name={USERINPUT.PASSWORD_CONFIRM.NAME}
-          type={USERINPUT.PASSWORD_CONFIRM.TYPE}
-          placeholder={USERINPUT.PASSWORD_CONFIRM.PLACE_HOLDER}
-          title={USERINPUT.PASSWORD_CONFIRM.TITLE}
+          name={USER_INPUT.PASSWORD_CONFIRM.NAME}
+          type={USER_INPUT.PASSWORD_CONFIRM.TYPE}
+          placeholder={USER_INPUT.PASSWORD_CONFIRM.PLACE_HOLDER}
+          title={USER_INPUT.PASSWORD_CONFIRM.TITLE}
           success={isPasswordOk(password) && password === passwordConfirm}
-          errorMessage={USERINPUT.PASSWORD_CONFIRM.ERROR_MESSAGE}
-          successMessage={USERINPUT.PASSWORD_CONFIRM.SUCCESS_MESSAGE}
+          errorMessage={USER_INPUT.PASSWORD_CONFIRM.ERROR_MESSAGE}
+          successMessage={USER_INPUT.PASSWORD_CONFIRM.SUCCESS_MESSAGE}
           handleChange={handleInputChange}
           show={passwordConfirm.length > 0}
         />


### PR DESCRIPTION
## 🪄 변경사항
### 회원가입 성공 / 실패 모달창 출력
- 회원가입 성공시 로그인하러 가기 모달창
- 회원가입 실패시 (중복된 이메일 시도시) 오류 모달창

## 🖥 결과 화면
<img width="301" alt="스크린샷 2023-09-08 오후 3 47 25" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/71740032/fca7b946-451c-467b-b1e6-79a9c2da20c9">
<img width="299" alt="스크린샷 2023-09-08 오후 3 48 03" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/71740032/1b312b05-75f7-425a-98fa-a9ef80810f6b">

## ✏️ PR 포인트

회원가입 성공시 로그인하러 가기 모달창이 출력되며 로그인하러 가기 버튼을 누르면 'login'페이지로 이동합니다.
중복된 이메일으로 회원가입 시도시 오류 모달창이 출력되며 확인 버튼을 누르면 모달창이 닫히고 다시 회원가입할 수 있습니다.
