### PR TITLE
✨profile/follow follow,unfollow 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "axios": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-query": "^3.39.3",
     "react-router-dom": "^6.15.0",
     "recoil": "^0.7.7"
   },
@@ -35,7 +34,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "prettier": "^3.0.3",
-    "sass": "^1.66.1",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vite-tsconfig-paths": "^4.2.0"

--- a/src/apis/follow/index.ts
+++ b/src/apis/follow/index.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import { API_BASE_URL } from '../../constants/Api';
+
+const postFollowUser = async (userId: string) => {
+  const response = await axios.post(
+    `${API_BASE_URL}/follow/create`,
+    { userId },
+    {
+      headers: {
+        // test token
+        Authorization:
+          'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjY0ZmYxNmNjMTY5Yzc5MDU3YjVmOGVjMCIsImVtYWlsIjoibmFuYTEyNEBuYXZlci5jb20ifSwiaWF0IjoxNjk0NDM5MzE1fQ.heYeAayvX78n0NooS-7H4HlbeHCvquXdFl7tRIVkEHM'
+      }
+    }
+  );
+  return response.data;
+};
+
+const deleteUnfollowUser = async (userId: string) => {
+  const response = await axios.delete(`${API_BASE_URL}/follow/delete`, {
+    data: { id: userId },
+    headers: {
+      // test token
+      Authorization:
+        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjY0ZmYxNmNjMTY5Yzc5MDU3YjVmOGVjMCIsImVtYWlsIjoibmFuYTEyNEBuYXZlci5jb20ifSwiaWF0IjoxNjk0NDM5MzE1fQ.heYeAayvX78n0NooS-7H4HlbeHCvquXdFl7tRIVkEHM'
+    }
+  });
+  return response.data;
+};
+
+export { postFollowUser, deleteUnfollowUser };

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient();
 

--- a/src/pages/profile/components/FollowUser/FollowUser.style.ts
+++ b/src/pages/profile/components/FollowUser/FollowUser.style.ts
@@ -5,7 +5,7 @@ export const FollowUserContainer = styled.div`
   justify-content: space-between;
   padding: 0 14px;
   height: 80px;
-  border-bottom: 1px solid ${({ theme }) => theme.color.greyLight};
+  border-bottom: 0.5px solid ${({ theme }) => theme.color.greyLight};
 
   & > button {
     display: inline-block;

--- a/src/pages/profile/components/FollowUser/FollowUser.tsx
+++ b/src/pages/profile/components/FollowUser/FollowUser.tsx
@@ -1,28 +1,74 @@
+import { useState } from 'react';
 import { Button as FollowButton } from '@components/Button';
 import { FollowUserContainer } from './FollowUser.style';
 import { FollowUserInfo } from '../FollowUserInfo';
-import { FollowUserData } from '../../types';
+import { Follow } from '@types';
+import { useQuery } from '@tanstack/react-query';
+import { deleteUnfollowUser } from '@apis/follow';
+import { postFollowUser } from '@apis/follow';
 
 // TODO : follow, following logic 추가될 예정
 
 interface FollowUserItemProps {
-  data: FollowUserData;
+  followUserData: Follow;
   following: boolean;
 }
 
-const FollowUserItem = ({ data, following }: FollowUserItemProps) => {
+const FollowUserItem = ({ followUserData, following }: FollowUserItemProps) => {
+  const [follow, setFollow] = useState(true);
+
+  const {
+    status,
+    data: followData,
+    refetch
+  } = useQuery({
+    queryKey: ['follow'],
+    queryFn: async () => {
+      let data = {};
+      console.log(follow);
+      if (follow) {
+        data = await deleteUnfollowUser(followUserData._id);
+      } else {
+        console.log(followUserData.user);
+        data = await postFollowUser(followUserData.user);
+      }
+
+      return data;
+    },
+    enabled: false
+  });
+
+  console.log(followData);
+
   return (
     <FollowUserContainer>
-      <FollowUserInfo userData={data} />
-      {following && (
-        <FollowButton
-          width={68}
-          height={30}
-          label='팔로우'
-          dark={true}
-          bold={true}
-        />
-      )}
+      <FollowUserInfo userData={followUserData} />
+      {following &&
+        (follow ? (
+          <FollowButton
+            width={68}
+            height={30}
+            label='팔로우'
+            dark={false}
+            bold={true}
+            handleClick={async () => {
+              await refetch();
+              setFollow((prev) => !prev);
+            }}
+          />
+        ) : (
+          <FollowButton
+            width={68}
+            height={30}
+            label='팔로잉'
+            dark={true}
+            bold={true}
+            handleClick={() => {
+              refetch();
+              setFollow((prev) => !prev);
+            }}
+          />
+        ))}
     </FollowUserContainer>
   );
 };

--- a/src/pages/profile/components/FollowUserInfo/FollowUserInfo.tsx
+++ b/src/pages/profile/components/FollowUserInfo/FollowUserInfo.tsx
@@ -1,25 +1,34 @@
 import { FollowUserInfoContainer } from './FollowUserInfo.style';
 import { UserId, UserName } from '@components/UserText';
 import { BadgeAvatar } from '@components/Avatar';
-import { FollowUserData } from '../../types';
+import { Follow } from '@types';
+import { useQuery } from '@tanstack/react-query';
+import { getUserData } from '@apis/user/getUserData';
 
 interface FollowUserInfoProps {
-  userData: FollowUserData;
+  userData: Follow;
 }
 
 const FollowUserInfo = ({ userData }: FollowUserInfoProps) => {
-  const { fullName, email, isOnline, image } = userData;
+  const userId = userData.user;
 
-  return (
+  const { status, data: user } = useQuery({
+    queryKey: ['followUser', userId],
+    queryFn: async () => await getUserData(userId)
+  });
+
+  return status === 'loading' ? (
+    <span>Loading..</span>
+  ) : (
     <FollowUserInfoContainer>
       <BadgeAvatar
-        alt={fullName}
-        src={image}
+        alt={user.fullName}
+        src={'https://picsum.photos/200/300'}
         size={39}
-        online={isOnline}
+        online={user.isOnline}
       />
-      <UserId email={email} />
-      <UserName>{fullName}</UserName>
+      <UserId email={user.email} />
+      <UserName>{user.fullName}</UserName>
     </FollowUserInfoContainer>
   );
 };

--- a/src/pages/profile/components/FollowUsers/FollowUsers.tsx
+++ b/src/pages/profile/components/FollowUsers/FollowUsers.tsx
@@ -1,39 +1,33 @@
 import { FollowUser } from '../FollowUser';
-import { FollowUserData } from '../../types';
+import { Follow } from '@types';
 
 const dumyData = [
   {
-    _id: '1234',
-    fullName: '물푸른',
-    isOnline: true,
-    email: 'bluewater@naver.com',
-    image: 'https://picsum.photos/200/300'
-  },
-  {
-    _id: '12345',
-    fullName: '수연조',
-    isOnline: false,
-    email: 'suyeon@naver.com',
-    image: 'https://picsum.photos/200/300'
+    _id: '64ff44d8e044e9076a2cb39e',
+    user: '64ff1661169c79057b5f8eb8',
+    follower: '64ff16cc169c79057b5f8ec0',
+    createdAt: '2023-09-11T16:48:24.723Z',
+    updatedAt: '2023-09-11T16:48:24.723Z',
+    __v: 0
   }
 ];
 
 interface FollowUsersProps {
   following: boolean;
-  data?: FollowUserData[];
+  data?: Follow[];
 }
 
 const FollowUsers = ({ following, data = dumyData }: FollowUsersProps) => {
   return (
-    <div>
-      {data.map((element) => (
+    <>
+      {data.map((element: Follow) => (
         <FollowUser
-          data={element}
+          followUserData={element}
           key={element._id}
           following={following}
         />
       ))}
-    </div>
+    </>
   );
 };
 export default FollowUsers;

--- a/src/pages/profile/components/ProfileCarousel/ProfileCarousel.tsx
+++ b/src/pages/profile/components/ProfileCarousel/ProfileCarousel.tsx
@@ -5,6 +5,7 @@ import {
 import { useCarousel } from '../../hooks/useCarousel';
 import { useRecoilState } from 'recoil';
 import { selectedTabIndexState } from '../../states/selectedTabIndex';
+import { FollowUsers } from '../FollowUsers';
 
 interface ProfileCarouselProps {
   totalIndex: number;
@@ -23,9 +24,13 @@ const ProfileCarousel = ({ totalIndex }: ProfileCarouselProps) => {
   return (
     <ProfileCarouselContainer ref={carouselRef}>
       <ProfileCarouselItem>0</ProfileCarouselItem>
-      <ProfileCarouselItem>1</ProfileCarouselItem>
-      <ProfileCarouselItem>2</ProfileCarouselItem>
-      <ProfileCarouselItem>3</ProfileCarouselItem>
+      <ProfileCarouselItem>
+        <FollowUsers following={true}></FollowUsers>
+      </ProfileCarouselItem>
+      <ProfileCarouselItem>
+        <FollowUsers following={false}></FollowUsers>
+      </ProfileCarouselItem>
+      <ProfileCarouselItem>4</ProfileCarouselItem>
     </ProfileCarouselContainer>
   );
 };

--- a/src/pages/profile/types/index.ts
+++ b/src/pages/profile/types/index.ts
@@ -1,7 +1,0 @@
-export interface FollowUserData {
-  _id: string;
-  fullName: string;
-  isOnline: boolean;
-  email: string;
-  image: string;
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "@types/*": ["./src/types/*"],
       "@constants/*": ["./src/constants/*"],
       "@colors/*": ["./src/colors/*"],
+      "@apis/*": ["./src/apis/*"],
       "@/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
## 🪄 변경사항
1. 팔로잉,팔로우 컴포넌트를 캐러셀에 넣어놨습니다.
2. 팔로우, 팔로잉 전부 가능합니다. 현재는 더미데이터라 작동은 안되지만 구현 동작 확인 된 상태입니다.
3. apis폴더 경로 별칭 추가했습니다.
4. apis/follow/index.ts 파일에 네트워크 함수 확인할 수 있습니다.

## 🖥 결과 화면
<img width="542" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/65156388/4f360aee-c8e7-4f3c-b6da-5b3a92c4f71b">

## ✏️ PR 포인트
음... follow 버튼을 눌렀을 때 네트워크요청과 상태변화가 둘다 일어나는데 둘다 비동기다보니 async await을 썼습니다. 이렇게 쓰는게 적절할지? 일단 혜성님이 전달해주는 유저 데이터로 구현을 마치고 금요일 리팩토링 때 얘기해봐도 좋을 것 같습니다.
