### PR TITLE
🚨 Fix: Footer 링크 수정 및 테두리 제거

### DIFF
--- a/src/components/Footer/Footer.style.ts
+++ b/src/components/Footer/Footer.style.ts
@@ -7,9 +7,6 @@ export const StyledFooter = styled.footer`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-top: 0.5px ${({ theme }) => theme.color.greyLight} solid;
-  border-bottom: 1.5px ${({ theme }) => theme.color.black} solid;
-  border-left: 1.5px ${({ theme }) => theme.color.black} solid;
-  border-right: 1.5px ${({ theme }) => theme.color.black} solid;
+  border-top: 0.03125rem ${({ theme }) => theme.color.greyLight} solid;
   padding: 0 35px;
 `;

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { Link } from '../Link';
 import { StyledFooter } from './Footer.style';
 
 const iconInfos = [
-  { name: 'home', size: 35, link: '/' },
+  { name: 'home', size: 35, link: '/posts' },
   { name: 'self_improvement', size: 35, link: '/meditation' },
   { name: 'person', size: 35, link: '/profile:userId' }
 ];


### PR DESCRIPTION
## 🪄 변경사항

Footer 첫번째 아이콘 링크를 '/'에서 '/posts'로 수정했습니다.
Footer의 하단 및 측면 테두리를 제거했습니다.

## 🖥 결과 화면
<img width="465" alt="스크린샷 2023-09-12 오후 3 27 30" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/69716992/d6e40874-53a2-488f-be6a-05a3fec3866a">


## ✏️ PR 포인트

(생략)
