### PR TITLE
✨ Feat: Confirm 컴포넌트 버튼 커스텀 가능

### DIFF
--- a/src/components/Confirm/Confirm.style.ts
+++ b/src/components/Confirm/Confirm.style.ts
@@ -65,3 +65,5 @@ export const NavButtonContainer = styled.div`
     margin: 0 10px;
   }
 `;
+
+export const CancelButtonDefaultEvent = styled.div``;

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react';
-import { Button } from '../Button';
+import React, { useState } from 'react';
 import { Link } from '../Link';
 import {
   StyledDeemBackground,
   StyledConfirmBackground,
   IconContainer,
   ContentContainer,
-  NavButtonContainer
+  NavButtonContainer,
+  CancelButtonDefaultEvent
 } from './Confirm.style';
 
 interface ConfirmProps {
@@ -17,43 +17,32 @@ interface ConfirmProps {
   content: string;
   contentFontSize: number;
   nextPageLink: string;
+  CancelButton: React.ReactNode;
+  ConfirmButton: React.ReactNode;
 }
 
 const Confirm = ({
-  width = 330,
-  height = 390,
   emoji,
-  emojiSize = 80,
   content,
   contentFontSize = 16,
-  nextPageLink
+  nextPageLink,
+  CancelButton,
+  ConfirmButton
 }: Partial<ConfirmProps>) => {
   const [disabled, setDisabled] = useState(false);
   return (
     <StyledDeemBackground disabled={disabled}>
       <StyledConfirmBackground
-        width={width}
-        height={height}>
-        <IconContainer emojiSize={emojiSize}>{emoji}</IconContainer>
+        width={330}
+        height={390}>
+        <IconContainer emojiSize={80}>{emoji}</IconContainer>
         <ContentContainer contentFontSize={contentFontSize}>
           {content}
           <NavButtonContainer>
-            <Button
-              handleClick={() => setDisabled(true)}
-              width={120}
-              height={50}
-              dark={false}
-              bold={false}
-              label={'취소'}></Button>
-            <Link pageLink={nextPageLink}>
-              <Button
-                width={120}
-                height={50}
-                dark={true}
-                bold={true}
-                label={'확인'}
-              />
-            </Link>
+            <CancelButtonDefaultEvent onClick={() => setDisabled(true)}>
+              {CancelButton}
+            </CancelButtonDefaultEvent>
+            <Link pageLink={nextPageLink}>{ConfirmButton}</Link>
           </NavButtonContainer>
         </ContentContainer>
       </StyledConfirmBackground>


### PR DESCRIPTION
## 🪄 변경사항

- Confirm 컴포넌트의 '확인', '취소' 버튼을 이제 사용처에서 커스텀 해줄 수 있습니다. (사용법은 노션 컴포넌트 설명서 페이지 참고)
- width, height, emojiSize Prop을 기본값으로 두어서 이제 더 이상 받지 않습니다.

## 🖥 결과 화면

(생략)

## ✏️ PR 포인트

(생략)
