### PR TITLE
🚨 Fix: Confirm 취소 클릭시 명상 끝내기 버튼 비활성화 이슈 해결

### DIFF
--- a/src/pages/meditation/Meditation.tsx
+++ b/src/pages/meditation/Meditation.tsx
@@ -1,13 +1,14 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import MeditationLabel from '@pages/meditation/components/MeditationLabel';
 import MeditationTimer from '@pages/meditation/components/MeditationTimer';
 import MeditationTimeSetter from '@pages/meditation/components/MeditationTimeSetter';
 import { MeditationPage } from './Meditation.style';
 import { endButtonPushed } from '@pages/meditation/components/MeditationEndButton/MeditationEndButton';
 import { Confirm } from '@components/Confirm';
+import { Button } from '@components/Button';
 
 export const Meditation = () => {
-  const confirmCaptured = useRecoilValue(endButtonPushed);
+  const [confirmCaptured, setConfirmCaptured] = useRecoilState(endButtonPushed);
   return (
     <>
       <MeditationPage>
@@ -16,13 +17,29 @@ export const Meditation = () => {
         <MeditationTimeSetter />
         {confirmCaptured && (
           <Confirm
-            width={329}
-            height={389}
             emoji={'🧘🏻'}
-            emojiSize={70}
             content={'정말 명상을 끝내시겠어요?'}
             contentFontSize={18}
             nextPageLink={'/'}
+            CancelButton={
+              <Button
+                width={120}
+                height={50}
+                bold={true}
+                dark={false}
+                label={'취소'}
+                handleClick={() => setConfirmCaptured(false)}
+              />
+            }
+            ConfirmButton={
+              <Button
+                width={120}
+                height={50}
+                bold={true}
+                dark={true}
+                label={'끝내기'}
+              />
+            }
           />
         )}
       </MeditationPage>


### PR DESCRIPTION
## 🪄 변경사항

명상 페이지에서 명상 도중에 명상 끝내기 버튼을 눌렀다가 취소하면 해당 버튼이 작동하지 않게 되는 문제를 해결했습니다!

-> Meditation 컴포넌트에서 Confirm 컴포넌트에 대해 EndButton의 상태를 제어할 수 있는 콜백을 Prop으로 전달하도록 수정

## 🖥 결과 화면
![Sep-13-2023 14-10-36](https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/69716992/ae35e47a-b90a-4732-8782-b325f13d4e61)


## ✏️ PR 포인트

딱...히 신경써서 봐주셔야 할 부분은 없지만 Recoil 상태 관리 말고도 EndButton과 Meditation 페이지가 Confirm이 취소되거나 EndButton이 눌렸는지 알 수 있는 다른 방법이 생각나시면 알려주세요!
