### PR TITLE
✨ Feat: PrivateRoute 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import { RecoilRoot } from 'recoil';
+
+import PrivateRoute from '@utils/PrivateRoute';
 import LandingPage from './pages/landing';
 import Layout from './pages/layout';
 import Profile from './pages/profile';
@@ -17,11 +19,11 @@ function App() {
             <Route element={<Layout />}>
               <Route
                 path='/meditation'
-                element={<Meditation />}
+                element={<PrivateRoute path='/meditation' element={Meditation} />}
               />
               <Route
                 path='/profile/:userId'
-                element={<Profile />}
+                element={<PrivateRoute path='/profile/userId' element={Profile} />}
               />
             </Route>
             <Route

--- a/src/utils/PrivateRoute.tsx
+++ b/src/utils/PrivateRoute.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/states/userState';
+
+interface PrivateRouteProps {
+  path: string,
+  element: () => JSX.Element;
+}
+
+const PrivateRoute = ({ path, element }: PrivateRouteProps) => {
+  const RouteComponent = element;
+  const userInfo = useRecoilValue(userState);
+
+  if (userInfo === null) {
+    return <Navigate to={`/login?redirectUrl=${path}`} />
+  }
+  if (userInfo.token === undefined) {
+    return <Navigate to={`/login?redirectUrl=${path}`} />
+  }
+
+  return <RouteComponent />; 
+}
+
+export default PrivateRoute;


### PR DESCRIPTION
## 🪄 변경사항

### PrivateRoute 구현

인증되지 않은 사용자가 로그인이 필요한 서비스에 접근하려고 하는 경우 JWT 토큰을 검사하여 Login 페이지로 이동하는 라우터 기능을 구현했습니다.

인증되지 않은 사용자의 경우 로그인 페이지로 이동합니다. 로그인이 성공하면 리다이렉트 페이지로 이동합니다.

```
/login?redirectUrl=/meditation
```

## 🖥 결과 화면

```
/login?ridrectUrl=/meditation
```

<img width="485" alt="Untitled" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/80307321/f743aa1e-1d91-47dd-9089-af25f3b0a848">

```
/meditation
```

<img width="407" alt="Untitled2" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/80307321/8bb1c9f6-8f39-4998-ab73-8c2e4c7b7417">

## ✏️ PR 포인트

궁금하거나 수정해야할 사항 자유롭게 남겨주세요! 
