### PR TITLE
🔨 Refactor: Profile/FollowAPI

### DIFF
--- a/src/apis/follow/index.ts
+++ b/src/apis/follow/index.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { API_BASE_URL } from '@constants/Api';
+import { Follow } from '@/types';
 
 const postFollowUser = async (userId: string, token: string) => {
-  const response = await axios.post(
+  const response = await axios.post<Follow>(
     `${API_BASE_URL}/follow/create`,
     { userId },
     {
@@ -15,7 +16,7 @@ const postFollowUser = async (userId: string, token: string) => {
 };
 
 const deleteFollowUser = async (userId: string, token: string) => {
-  const response = await axios.delete(`${API_BASE_URL}/follow/delete`, {
+  const response = await axios.delete<Follow>(`${API_BASE_URL}/follow/delete`, {
     data: { id: userId },
     headers: {
       Authorization: token

--- a/src/apis/follow/index.ts
+++ b/src/apis/follow/index.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import { API_BASE_URL } from '@constants/Api';
-import { Follow } from '@/types';
 
 const postFollowUser = async (userId: string, token: string) => {
   const response = await axios.post(
@@ -25,13 +24,9 @@ const deleteFollowUser = async (userId: string, token: string) => {
   return response.data;
 };
 
-const getFollowUser = async (userId: string, element: Follow) => {
+const getFollowUser = async (userId: string) => {
   const response = await axios.get(`${API_BASE_URL}/users/${userId}`);
-  return {
-    _id: element._id,
-    user: response.data,
-    follower: element.user
-  };
+  return response.data;
 };
 
 export { postFollowUser, deleteFollowUser, getFollowUser };

--- a/src/apis/follow/index.ts
+++ b/src/apis/follow/index.ts
@@ -24,9 +24,4 @@ const deleteFollowUser = async (userId: string, token: string) => {
   return response.data;
 };
 
-const getFollowUser = async (userId: string) => {
-  const response = await axios.get(`${API_BASE_URL}/users/${userId}`);
-  return response.data;
-};
-
-export { postFollowUser, deleteFollowUser, getFollowUser };
+export { postFollowUser, deleteFollowUser };

--- a/src/pages/profile/components/FollowUsers.tsx
+++ b/src/pages/profile/components/FollowUsers.tsx
@@ -1,6 +1,6 @@
 import { useQueries } from '@tanstack/react-query';
 import { Follow, User } from '@/types';
-import { getFollowUser } from '@apis/follow';
+import { getUser } from '@apis/user';
 import { FollowUser } from '@pages/profile/components';
 
 const dumyData = [
@@ -32,7 +32,7 @@ const FollowUsers = ({ following, data = dumyData }: FollowUsersProps) => {
     queries: data.map((element) => {
       return {
         queryKey: ['followUser', element._id],
-        queryFn: () => getFollowUser(element.user),
+        queryFn: () => getUser(element.user),
         select: (data: User) => {
           return {
             ...element,

--- a/src/pages/profile/components/FollowUsers.tsx
+++ b/src/pages/profile/components/FollowUsers.tsx
@@ -1,5 +1,5 @@
 import { useQueries } from '@tanstack/react-query';
-import { Follow } from '@/types';
+import { Follow, User } from '@/types';
 import { getFollowUser } from '@apis/follow';
 import { FollowUser } from '@pages/profile/components';
 
@@ -32,7 +32,14 @@ const FollowUsers = ({ following, data = dumyData }: FollowUsersProps) => {
     queries: data.map((element) => {
       return {
         queryKey: ['followUser', element._id],
-        queryFn: () => getFollowUser(element.user, element)
+        queryFn: () => getFollowUser(element.user),
+        select: (data: User) => {
+          return {
+            ...element,
+            user: data
+          };
+        },
+        enabled: data.length > 0
       };
     })
   });


### PR DESCRIPTION
## 🪄 변경사항
followUsers컴포넌트에서 user 데이터를 받은 후 데이터를 정제하는 과정을 수정했습니다. [e3e4a28](https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/pull/60/commits/e3e4a28bcdadd9d11cc35dd1a72a239122072589)
이전에는 getFollowUsers에 props로 이전 데이터를 받고 정제 후 return해줬습니다.
이제는 react query에서 제공하는 select 옵션을 통해 react query 안에서 데이터를 정제합니다. 