### PR TITLE
🚨 Fix: 이전 포스팅 불러오기 UI 수정

### DIFF
--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -55,7 +55,11 @@ const Confirm = ({
               <CancelButtonDefaultEvent onClick={() => setDisabled(true)}>
                 {FormedCancelButton}
               </CancelButtonDefaultEvent>
-              <Link pageLink={nextPageLink}>{FormedConfirmlButton}</Link>
+              <Link
+                state={linkState}
+                pageLink={nextPageLink}>
+                {FormedConfirmlButton}
+              </Link>
             </NavButtonContainer>
           </ContentContainer>
         </StyledConfirmBackground>

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -17,7 +17,7 @@ interface ConfirmProps {
   nextPageLink: string;
   CancelButton: React.ReactNode | (() => JSX.Element);
   ConfirmButton: React.ReactNode | (() => JSX.Element);
-  linkState: { [key: string]: any };
+  linkState?: { [key: string]: any };
 }
 
 const Confirm = ({

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -31,7 +31,7 @@ const Confirm = ({
 }: Partial<ConfirmProps>) => {
   const [disabled, setDisabled] = useState(false);
   const [domReady, setDomReady] = useState(false);
-  
+
   const FormedCancelButton =
     typeof CancelButton === 'function' ? CancelButton() : CancelButton;
   const FormedConfirmlButton =
@@ -53,9 +53,9 @@ const Confirm = ({
             {content}
             <NavButtonContainer>
               <CancelButtonDefaultEvent onClick={() => setDisabled(true)}>
-                {CancelButton}
+                {FormedCancelButton}
               </CancelButtonDefaultEvent>
-              <Link pageLink={nextPageLink}>{ConfirmButton}</Link>
+              <Link pageLink={nextPageLink}>{FormedConfirmlButton}</Link>
             </NavButtonContainer>
           </ContentContainer>
         </StyledConfirmBackground>

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -9,7 +9,7 @@ interface LinkProps {
   pageLink: string;
   size: number;
   color: string;
-  state: State;
+  state?: State;
 }
 
 const Link = ({

--- a/src/pages/posting/Posting.tsx
+++ b/src/pages/posting/Posting.tsx
@@ -34,7 +34,7 @@ const Posting = () => {
     if (location.state === null) {
       navigate('/404');
     }
-
+    console.log(location.state);
     setMeditationInfo(location.state);
   }, []);
 


### PR DESCRIPTION
## 🪄 변경사항

### Confirm UI 에서 취소창이 보이지않던 문제

- JSX.Element 와 ReactNode 를 한꺼번에 사용할 수 있도록 하면서 통일한 변수를 사용하지 않아 생긴 문제였습니다.

### Post 다시 불러오기 문제

- Confirm 컴포넌트의 linkstate 가 사용이 되지 않고 있던 문제를 해결했습니다.

## 🖥 결과 화면

<img width="311" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/80307321/1e9d28d9-fc5c-4b4f-abf8-e58dc4fad569">

