### PR TITLE
💄 Style: Footer Icon Style 변경 외 1건

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -37,7 +37,7 @@ export const Footer = () => {
             name={icon.name}
             size={icon.size}
             fill={icon.link === location.pathname}
-            color={icon.link === location.pathname ? 'purpleLight' : 'black'}
+            color={icon.link === location.pathname ? 'purpleNormal' : 'black'}
           />
         </Link>
       ))}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,6 +3,7 @@ import { Link } from '../Link';
 import { StyledFooter } from './Footer.style';
 import useSessionStorage from '@hooks/useSessionStorage';
 import { User } from '@/types/User';
+import { useLocation } from 'react-router-dom';
 
 export const Footer = () => {
   const [userData] = useSessionStorage<Pick<User, '_id' | 'token'>>(
@@ -15,9 +16,10 @@ export const Footer = () => {
 
   const iconInfos = [
     { name: 'home', size: 35, link: '/posts' },
-    { name: 'self_improvement', size: 35, link: '/meditation' },
+    { name: 'spa', size: 35, link: '/meditation' },
     { name: 'person', size: 35, link: `/profile/${userData._id}` }
   ];
+  const location = useLocation();
 
   return (
     <StyledFooter>
@@ -34,7 +36,8 @@ export const Footer = () => {
           <Icon
             name={icon.name}
             size={icon.size}
-            color='black'
+            fill={icon.link === location.pathname}
+            color={icon.link === location.pathname ? 'purpleLight' : 'black'}
           />
         </Link>
       ))}

--- a/src/components/Icon/Icon.style.ts
+++ b/src/components/Icon/Icon.style.ts
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
+import { color } from '@styles/colors';
 
 export const StyledIcon = styled.span<{
   size: number;
-  color: string;
+  color: keyof typeof color;
   fill?: string;
 }>`
   color: ${({ theme, color }) => theme.color[color]};

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,10 +1,11 @@
 import { StyledIcon } from './Icon.style';
-import { GOOGLE_ICON_CLASSNAME } from '../../constants/Components';
+import { GOOGLE_ICON_CLASSNAME } from '@constants/Components';
+import { color } from '@styles/colors';
 
 interface IconProps {
   size: number;
   name: string;
-  color: string;
+  color: keyof typeof color;
   fill?: boolean;
 }
 

--- a/src/components/Link/Link.style.ts
+++ b/src/components/Link/Link.style.ts
@@ -1,7 +1,11 @@
 import { NavLink } from 'react-router-dom';
+import { color } from '@styles/colors';
 import styled from '@emotion/styled';
 
-export const StyledNavLink = styled(NavLink)<{ size: number; color: string }>`
+export const StyledNavLink = styled(NavLink)<{
+  size: number;
+  color: keyof typeof color;
+}>`
   color: ${({ theme, color }) => theme.color[color]};
   font-size: ${({ size }) => size}px;
   text-decoration: none;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,5 @@
 import { StyledNavLink } from './Link.style';
+import { color } from '@styles/colors';
 
 interface State {
   [key: string]: any;
@@ -8,7 +9,7 @@ interface LinkProps {
   children: React.ReactNode;
   pageLink: string;
   size: number;
-  color: string;
+  color: keyof typeof color;
   state: State;
 }
 
@@ -16,7 +17,7 @@ const Link = ({
   children,
   pageLink,
   size = 14,
-  color = '#000',
+  color = 'black',
   state
 }: Partial<LinkProps>) => {
   return (

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,4 +1,5 @@
 export const color = {
+  purpleNormal: '#8653ab',
   purpleDark: '#47346d',
   purpleDarker: '#272038',
   purpleLight: '#b796d0',


### PR DESCRIPTION
## 🪄 변경사항

- 이제 선택한 페이지에 따라 푸터의 아이콘에 연보라색 + fill 속성이 적용됩니다!
- Link, Icon 공통 컴포넌트에 prop으로 전달되는 color 값에 string -> keyof typeof color 적용했습니다!

## 🖥 결과 화면
<img width="690" alt="스크린샷 2023-09-25 오후 3 51 24" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/69716992/f06be8d3-4885-4ad7-8732-30ff9ec5cfb4">


## ✏️ PR 포인트

생략!