### PR TITLE
🚨 Fix: 명상 일시정지하고 다른 페이지 이동 후 복귀했을 때 불필요한 UI 노출되는 문제 해결

### DIFF
--- a/src/pages/meditation/Meditation.style.ts
+++ b/src/pages/meditation/Meditation.style.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const MeditationPage = styled.div`
   ${({ theme }) => theme.style.flexCenter};
   flex-direction: column;
-  height: 100%;
+  height: 100vh;
   width: 100%;
   background: ${({ theme }) => theme.color.linearGradientPurple};
 `;

--- a/src/pages/meditation/Meditation.tsx
+++ b/src/pages/meditation/Meditation.tsx
@@ -1,6 +1,6 @@
 import { useRecoilState } from 'recoil';
 import { useState } from 'react';
-import { endButtonPushed } from './states';
+import { endButtonPushed, meditationStatus } from './states';
 import { MeditationPage } from './Meditation.style';
 import { ThemePicker } from '@components/ThemePicker';
 import { ThemeInfoType } from '@components/ThemePicker/ThemePicker';
@@ -19,6 +19,7 @@ const Meditation = () => {
   const [selectedTheme, setSelectedTheme] = useState(
     meditationChannelInfo.get(CONCENTRATION_KEY)
   );
+  const [status, setStatus] = useRecoilState(meditationStatus);
   const prevPosting = JSON.parse(sessionStorage.getItem('posting'));
 
   const handleCancelPrevPosting = () => {
@@ -48,14 +49,13 @@ const Meditation = () => {
         )}
         <MeditationLabel />
         <MeditationTimer />
-        <MeditationTimeSetter
-          id={selectedTheme.id}
-          label={selectedTheme.label}
-        />
-        <ThemePicker
-          themeInfo={meditationChannelInfo}
-          handleClickTheme={handleThemeInfo}
-        />
+        <MeditationTimeSetter themePicked={selectedTheme} />
+        {!status.started && (
+          <ThemePicker
+            themeInfo={meditationChannelInfo}
+            handleClickTheme={handleThemeInfo}
+          />
+        )}
         {confirmCaptured && (
           <MeditationCancelConfirm
             handleConfirmButton={handleMeditationCancel}

--- a/src/pages/meditation/components/MeditationTimeSetter.tsx
+++ b/src/pages/meditation/components/MeditationTimeSetter.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { Icon } from '@components/Icon';
@@ -17,26 +17,30 @@ import {
   TimeSetterContainer
 } from './MeditationTimeSetter.style';
 import MeditationEndButton from '@pages/meditation/components/MeditationEndButton';
-import { meditationTime, totalMeditationTime } from '@pages/meditation/states';
-import { Toast } from '@components/Toast';
+import {
+  meditationStatus,
+  meditationTime,
+  totalMeditationTime
+} from '@pages/meditation/states';
 import { ThemeInfoType } from '@components/ThemePicker/ThemePicker';
 
-const MeditationTimeSetter = (themePicked: ThemeInfoType) => {
+interface MeditationTimeSetterProps {
+  themePicked: ThemeInfoType;
+}
+
+const MeditationTimeSetter = ({ themePicked }: MeditationTimeSetterProps) => {
   const [time, setTime] = useRecoilState<number>(meditationTime);
   const longClickIdRef = useRef<number>(null);
   const [totalTime, setTotalTime] = useRecoilState(totalMeditationTime);
+  const [status, setStatus] = useRecoilState(meditationStatus);
 
-  const [meditationStatus, setMeditationStatus] = useState({
-    started: false,
-    ended: false
-  });
   const navigate = useNavigate();
   useEffect(() => {
     const handleStartMeditation = () => {
       if (totalTime === 0) {
         setTotalTime(time);
       }
-      setMeditationStatus({ ...meditationStatus, started: true });
+      setStatus({ ...status, started: true });
     };
 
     const handleEndMeditation = () => {
@@ -48,7 +52,7 @@ const MeditationTimeSetter = (themePicked: ThemeInfoType) => {
           validation: true
         }
       });
-      setMeditationStatus({ ...meditationStatus, ended: true });
+      setStatus({ ...status, ended: true });
     };
 
     document.addEventListener(
@@ -135,7 +139,7 @@ const MeditationTimeSetter = (themePicked: ThemeInfoType) => {
 
   return (
     <>
-      {!meditationStatus.started && (
+      {!status.started && (
         <TimeSetterContainer>
           <SetTimeButton
             onClick={() => handleTime(BUTTON_TYPE_SUB)}
@@ -173,9 +177,7 @@ const MeditationTimeSetter = (themePicked: ThemeInfoType) => {
           </SetTimeButton>
         </TimeSetterContainer>
       )}
-      {meditationStatus.started && !meditationStatus.ended && (
-        <MeditationEndButton />
-      )}
+      {status.started && !status.ended && <MeditationEndButton />}
     </>
   );
 };

--- a/src/pages/meditation/components/MeditationTimer.tsx
+++ b/src/pages/meditation/components/MeditationTimer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { Icon } from '@components/Icon';
 import formatTime from '@utils/formatTime';
@@ -50,6 +50,17 @@ const MeditationTimer = () => {
       startTimer();
     }
   };
+  useEffect(() => {
+    const headerEl = document.querySelector('header');
+    const footerEl = document.querySelector('footer');
+    if (paused) {
+      headerEl.style.display = 'flex';
+      footerEl.style.display = 'flex';
+    } else {
+      headerEl.style.display = 'none';
+      footerEl.style.display = 'none';
+    }
+  }, [paused]);
 
   return (
     <TimerContainer timerPaused={timerId && paused}>

--- a/src/pages/meditation/states/index.ts
+++ b/src/pages/meditation/states/index.ts
@@ -16,3 +16,8 @@ export const totalMeditationTime = atom({
   key: 'totalMeditationTime',
   default: 0
 });
+
+export const meditationStatus = atom({
+  key: 'meditationStatus',
+  default: { started: false, ended: false }
+});


### PR DESCRIPTION
## 🪄 변경사항

- 이제 명상 일시 정지 후 다른 페이지로 이동했다가 복귀해도 TimeSetter와 ThemePicker가 노출되지 않습니다!

## 🖥 결과 화면

![Sep-27-2023 08-45-13](https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/69716992/5546d050-dfc5-4935-a25a-dc5e2c24718c)


## ✏️ PR 포인트

결국 Recoil의 유혹을 이기지 못했는데 적절한 사용이었을까요?
사용 이유 : 원래는 명상 페이지 최상단에서 상태를 Prop으로 내려줬는데 페이지 이동했다가 복귀하면 초기화됨
