### PR TITLE
✨ Feat: 포스트 검색 결과에서 해당 항목 클릭 시 항목 상세 정보로 이동

### DIFF
--- a/src/components/PostPreview/PostPreview.tsx
+++ b/src/components/PostPreview/PostPreview.tsx
@@ -7,6 +7,8 @@ import {
   PreviewContainer
 } from './PostPreview.style';
 import { Link } from '@components/Link';
+import { openSearch } from '@pages/layout/states/openSearch';
+import { useSetRecoilState } from 'recoil';
 
 interface PostPreviewProps {
   post: EditedPost;
@@ -25,9 +27,13 @@ const PostPreview = ({
   const previewContent = `${content.substring(0, 100)}${
     content.length > 100 ? '...' : ''
   }`;
+  const setResultShown = useSetRecoilState(openSearch);
+  const handlePreviewClick = () => {
+    setResultShown(false);
+  };
 
   return (
-    <PreviewContainer>
+    <PreviewContainer onClick={handlePreviewClick}>
       <PostHeaderContainer>
         <PostHeader
           post={post}


### PR DESCRIPTION
## 🪄 변경사항

- 이제 포스트 검색 결과에서 해당 항목 클릭 시 항목 상세 정보로 이동할 수 있습니다!

## 🖥 결과 화면

급해서 생략!

## ✏️ PR 포인트

고생하셨습니다!
