### PR TITLE
🚨Fix : 팔로우 성공시 알림 요청에서 토큰 잘못된 값 전달 수정

### DIFF
--- a/src/apis/notice/index.ts
+++ b/src/apis/notice/index.ts
@@ -39,7 +39,7 @@ const postNotifications = async (
     notificationData,
     {
       headers: {
-        Authorization: token
+        Authorization: 'Bearer ' + token
       }
     }
   );


### PR DESCRIPTION
토큰 헤더를 공통적으로 관리하지 않으니 이런 일이 발생하는 군요...
리팩토링 할 때 Axios.create를 꼭 사용해봅시다