### PR TITLE
💄 Style: Footer 위치 고정, 레이어 순위 올리기

### DIFF
--- a/src/pages/layout/components/Footer.style.ts
+++ b/src/pages/layout/components/Footer.style.ts
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 
 export const StyledFooter = styled.footer`
-  background-color: white;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  background-color: ${({ theme }) => theme.color.white};
   width: 100%;
   height: 64px;
   display: flex;

--- a/src/styles/global.tsx
+++ b/src/styles/global.tsx
@@ -12,6 +12,7 @@ const style = css`
 
   #root {
     font-family: 'Pretendard Variable', sans-serif;
+    position: relative;
     width: 100%;
     height: 100%;
     max-width: 768px;


### PR DESCRIPTION

## 🪄 변경사항

### Footer 스타일 수정

- Footer 가 바닥에 고정되도록 했습니다.
- Skeleton UI 가 footer 보다 낮은 레이어 순위를 가져서 튀어나오지 않게 했습니다.

## 🖥 결과 화면

<img width="813" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/80307321/6b06a7c5-b567-44e3-a407-286d08f479cc">
