### PR TITLE
🔨 Refactoring: 글자 자르기 유틸함수로 분리하기

### DIFF
--- a/src/components/PostPreview/PostPreview.tsx
+++ b/src/components/PostPreview/PostPreview.tsx
@@ -1,14 +1,17 @@
+import { useSetRecoilState } from 'recoil';
+
 import type { EditedPost } from '@/types';
+
 import PostHeader from './PostHeader';
+import { Link } from '@components/Link';
+import { openSearch } from '@pages/layout/states/openSearch';
+import { shortenString } from '@utils/index';
 import {
   PostContent,
   PostContentContainer,
   PostHeaderContainer,
   PreviewContainer
 } from './PostPreview.style';
-import { Link } from '@components/Link';
-import { openSearch } from '@pages/layout/states/openSearch';
-import { useSetRecoilState } from 'recoil';
 
 interface PostPreviewProps {
   post: EditedPost;
@@ -24,9 +27,7 @@ const PostPreview = ({
   noneProfile = false
 }: PostPreviewProps) => {
   const { content, _id } = post;
-  const previewContent = `${content.substring(0, 100)}${
-    content.length > 100 ? '...' : ''
-  }`;
+  const previewContent = shortenString(content, 100);
   const setResultShown = useSetRecoilState(openSearch);
   const handlePreviewClick = () => {
     setResultShown(false);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import formatTime from './formatTime';
 import getMyFollowData from '@utils/GetMyFollowData';
 import getTotalMeditationTime from './getTotalMeditationTime';
+import shortenString from './shortenString';
 
-export { formatTime, getMyFollowData, getTotalMeditationTime };
+export { formatTime, getMyFollowData, getTotalMeditationTime, shortenString };

--- a/src/utils/shortenString.ts
+++ b/src/utils/shortenString.ts
@@ -1,0 +1,7 @@
+const shortenString = (sentence: string, stringLimit: number) => {
+  return `${sentence.substring(0, 100)}${
+    sentence.length > stringLimit ? '...' : ''
+  }`;
+};
+
+export default shortenString;


### PR DESCRIPTION
## 🪄 변경사항

### 글자를 자르는 로직을 util 폴더로 분리했습니다

글자와 제한 숫자를 받아 잘릴 문자열을 반환합니다.

```tsx
const shortenString = (sentence: string, stringLimit: number) => {
  return `${sentence.substring(0, 100)}${
    sentence.length > stringLimit ? '...' : ''
  }`;
};

export default shortenString;

```

## 🖥 결과 화면

<img width="574" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/80307321/b4f5100c-e8da-4360-8fc8-2c82c56c0ec3">

