### PR TITLE
🔨 Refactoring: SignUp 페이지 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.47.0",
         "react-router-dom": "^6.15.0",
         "recoil": "^0.7.7"
       },
@@ -4164,6 +4165,21 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7976,6 +7992,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-hook-form": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "axios": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.47.0",
     "react-router-dom": "^6.15.0",
     "recoil": "^0.7.7"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^4.33.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@types/react-router-dom": "^5.3.3",
-    "@tanstack/react-query-devtools": "^4.33.0",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "@vitejs/plugin-react-swc": "^3.3.2",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -16,6 +16,7 @@ interface ButtonProps {
   disabled?: boolean;
   padding?: boolean;
   backgroundColor?: keyof typeof color;
+  type?: 'button' | 'submit' | 'reset';
 }
 
 const Button = ({
@@ -31,7 +32,8 @@ const Button = ({
   children,
   disabled,
   border = 'transparent',
-  backgroundColor
+  backgroundColor,
+  type
 }: ButtonProps) => {
   return (
     <StyledButton
@@ -45,7 +47,8 @@ const Button = ({
       fontSize={fontSize}
       borderRadius={borderRadius}
       disabled={disabled}
-      backgroundColor={backgroundColor}>
+      backgroundColor={backgroundColor}
+      type={type}>
       {label}
       {children}
     </StyledButton>

--- a/src/components/FormInput/FormInput.style.ts
+++ b/src/components/FormInput/FormInput.style.ts
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+export const InputContainer = styled.div`
+  width: 100%;
+  max-width: 300px;
+  margin: 10px 0;
+`;
+export const Label = styled.label`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  font-weight: 700;
+  margin-left: 10px;
+  margin-bottom: 10px;
+`;
+
+export const Input = styled.input`
+  box-sizing: border-box;
+  width: 100%;
+  height: 45px;
+  padding-left: 10px;
+  font-size: 14px;
+  border: 1px solid ${({ theme }) => theme.color.white500};
+  border-radius: 10px;
+`;
+
+export const StyledTitle = styled.span`
+  min-height: 20px;
+  margin-right: 5px;
+  ${({ theme }) => theme.style.flexAlignCenter};
+`;
+
+export const ErrorMessage = styled.span`
+  line-height: 1.2;
+  min-width: 200px;
+  min-height: 20px;
+  ${({ theme }) => theme.style.flexAlignCenter};
+  color: ${({ theme }) => theme.color.redVivid};
+  font-size: 12px;
+  font-weight: 400;
+  white-space: pre-line;
+`;
+
+export const SuccessMessage = styled.span`
+  line-height: 1.2;
+  min-width: 200px;
+  min-height: 20px;
+  ${({ theme }) => theme.style.flexAlignCenter};
+  color: ${({ theme }) => theme.color.greenVivid};
+  font-size: 12px;
+  white-space: pre-line;
+  font-weight: 400;
+`;

--- a/src/components/FormInput/FormInput.tsx
+++ b/src/components/FormInput/FormInput.tsx
@@ -1,0 +1,63 @@
+import { useFormContext } from 'react-hook-form';
+import {
+  ErrorMessage,
+  Input,
+  InputContainer,
+  Label,
+  SuccessMessage,
+  StyledTitle
+} from './FormInput.style';
+
+interface FormInputProps {
+  name: string;
+  type: string;
+  success: boolean;
+  handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+  title: string;
+  errorMessage: string;
+  successMessage: string;
+  successColor: string;
+  errorColor: string;
+  show: boolean;
+}
+
+const FormInput = ({
+  name,
+  type = 'text',
+  title,
+  success,
+  placeholder,
+  errorMessage,
+  successMessage,
+  successColor,
+  errorColor,
+  show = false,
+  handleChange
+}: Partial<FormInputProps>) => {
+  const { register } = useFormContext();
+
+  return (
+    <InputContainer>
+      <Label>
+        <StyledTitle>{title}</StyledTitle>
+        {show && success && (
+          <SuccessMessage color={successColor}>{successMessage}</SuccessMessage>
+        )}
+        {show && !success && (
+          <ErrorMessage color={errorColor}>{errorMessage}</ErrorMessage>
+        )}
+      </Label>
+      <Input
+        type={type}
+        name={name}
+        placeholder={placeholder}
+        autoComplete={type === 'password' ? 'off' : 'on'}
+        onChange={(event) => handleChange(event)}
+        {...register(name)}
+      />
+    </InputContainer>
+  );
+};
+
+export default FormInput;

--- a/src/components/FormInput/index.tsx
+++ b/src/components/FormInput/index.tsx
@@ -1,0 +1,3 @@
+import FormInput from './FormInput';
+
+export { FormInput };

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
 import { useLocation, useNavigate } from 'react-router-dom';
 import postLogInUser from '@apis/login';
 import { Button } from '@components/Button';
-import { UserInput } from '@components/UserInput';
-import { USER_INPUT } from './constants';
+import { FormInput } from '@components/FormInput';
+import { USER_INPUT, LABEL } from './constants';
 import { GoToSignUp } from './components';
 import { LoginForm, ButtonContainer } from './Login.style';
 import useSessionStorage from '@hooks/useSessionStorage';
@@ -15,8 +16,9 @@ import {
 } from '@pages/landing/Landing.style';
 
 const Login = () => {
-  const [email, setEmail] = useState<string>('');
-  const [password, setPassword] = useState<string>('');
+  const methods = useForm();
+  const { watch } = methods;
+  const [email, password] = watch(['email', 'password']);
   const [errorCatched, setErrorCatched] = useState<boolean>(false);
   const navigate = useNavigate();
   const { search } = useLocation();
@@ -41,24 +43,7 @@ const Login = () => {
     }
   }, [userSessionData.token, navigate, redirectTo, search]);
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.preventDefault();
-    const { name, value } = event.target;
-
-    switch (name) {
-      case 'email':
-        setEmail(value);
-        break;
-      case 'password':
-        setPassword(value);
-        break;
-      default:
-        break;
-    }
-  };
-
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const onSubmit = () => {
     postLogInUser({ email, password })
       .then((res) => {
         const { user, token } = res.data;
@@ -79,34 +64,34 @@ const Login = () => {
       <HeadingContentContainer>
         <Heading />
       </HeadingContentContainer>
-      <LoginForm onSubmit={handleSubmit}>
-        <UserInput
-          name={USER_INPUT.EMAIL.NAME}
-          placeholder={USER_INPUT.EMAIL.PLACE_HOLDER}
-          title={USER_INPUT.EMAIL.TITLE}
-          handleChange={handleInputChange}
-          show={errorCatched}
-          errorMessage={USER_INPUT.ERROR_MESSAGE}
-        />
-        <UserInput
-          name={USER_INPUT.PASSWORD.NAME}
-          placeholder={USER_INPUT.PASSWORD.PLACE_HOLDER}
-          title={USER_INPUT.PASSWORD.TITLE}
-          handleChange={handleInputChange}
-          type={USER_INPUT.PASSWORD.TYPE}
-        />
-        <ButtonContainer>
-          <Button
-            label='로그인'
-            width={300}
-            height={45}
-            bold={false}
-            dark={true}
-            handleClick={() => handleSubmit}
+      <FormProvider {...methods}>
+        <LoginForm onSubmit={methods.handleSubmit(onSubmit)}>
+          <FormInput
+            name={USER_INPUT.EMAIL.NAME}
+            placeholder={USER_INPUT.EMAIL.PLACE_HOLDER}
+            title={USER_INPUT.EMAIL.TITLE}
+            show={errorCatched}
+            errorMessage={USER_INPUT.ERROR_MESSAGE}
           />
-        </ButtonContainer>
-        <GoToSignUp />
-      </LoginForm>
+          <FormInput
+            name={USER_INPUT.PASSWORD.NAME}
+            placeholder={USER_INPUT.PASSWORD.PLACE_HOLDER}
+            title={USER_INPUT.PASSWORD.TITLE}
+            type={USER_INPUT.PASSWORD.TYPE}
+          />
+          <ButtonContainer>
+            <Button
+              label={LABEL.LOG_IN}
+              width={300}
+              height={45}
+              bold={false}
+              dark={true}
+              handleClick={() => methods.handleSubmit(onSubmit)}
+            />
+          </ButtonContainer>
+          <GoToSignUp />
+        </LoginForm>
+      </FormProvider>
     </LandingMain>
   );
 };

--- a/src/pages/login/constants/index.ts
+++ b/src/pages/login/constants/index.ts
@@ -14,7 +14,7 @@ const USER_INPUT = {
 };
 
 const LABEL = {
-  SIGN_UP: '회원가입'
+  LOG_IN: '로그인'
 };
 
 const MESSAGE = {

--- a/src/pages/login/constants/index.ts
+++ b/src/pages/login/constants/index.ts
@@ -14,7 +14,8 @@ const USER_INPUT = {
 };
 
 const LABEL = {
-  LOG_IN: '로그인'
+  LOG_IN: '로그인',
+  SIGN_UP: '회원가입'
 };
 
 const MESSAGE = {

--- a/src/pages/signup/components/SignUpForm.style.ts
+++ b/src/pages/signup/components/SignUpForm.style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const SignUpForm = styled.form`
+export const SignUpFormContainer = styled.form`
   ${({ theme }) => theme.style.flexCenter};
   flex-direction: column;
   box-sizing: border-box;

--- a/src/pages/signup/components/SignUpForm.tsx
+++ b/src/pages/signup/components/SignUpForm.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Button } from '@components/Button';
+import { FormInput } from '@components/FormInput';
+import { isEmailOk, isNicknameOk, isPasswordOk } from '../validations';
+import { USER_INPUT, BUTTON } from '../constants';
+import { SignUpFormContainer, ButtonContainer } from './SignUpForm.style';
+import { SignUpValidations } from '../validations';
+import postSignUpUser from '@apis/signup';
+import { useNavigate } from 'react-router-dom';
+import { Alert } from '@components/Alert';
+import { MODAL } from '../constants';
+
+const SignUpForm = () => {
+  interface SignUpFormData {
+    email: string;
+    nickname: string;
+    password: string;
+    passwordConfirm: string;
+  }
+  const [emailErrorCatched, setEmailErrorCatched] = useState<boolean>(false);
+  const [signupSucceed, setSignupSucceed] = useState<boolean>(false);
+  const methods = useForm<SignUpFormData>();
+  const { watch } = methods;
+  const [email, nickname, password, passwordConfirm] = watch([
+    'email',
+    'nickname',
+    'password',
+    'passwordConfirm'
+  ]);
+
+  const navigate = useNavigate();
+  const onSubmit = () => {
+    if (SignUpValidations({ email, nickname, password, passwordConfirm })) {
+      postSignUpUser({
+        email,
+        password,
+        fullName: nickname
+      })
+        .then(() => {
+          setSignupSucceed(true);
+        })
+        .catch((error) => {
+          console.log(error);
+          setEmailErrorCatched(true);
+        });
+    }
+    setEmailErrorCatched(false);
+    return;
+  };
+
+  return (
+    <>
+      {emailErrorCatched && (
+        <Alert
+          emoji={MODAL.ERROR.EMOJI}
+          content={MODAL.ERROR.CONTENT}
+          buttonLabel={MODAL.ERROR.LABEL}
+        />
+      )}
+      {signupSucceed && (
+        <Alert
+          emoji={MODAL.SUCCESS.EMOJI}
+          content={MODAL.SUCCESS.CONTENT}
+          buttonLabel={MODAL.SUCCESS.LABEL}
+          nextPageLink='/login'
+        />
+      )}
+      <FormProvider {...methods}>
+        <SignUpFormContainer onSubmit={methods.handleSubmit(onSubmit)}>
+          <FormInput
+            name={USER_INPUT.EMAIL.NAME}
+            placeholder={USER_INPUT.EMAIL.PLACE_HOLDER}
+            title={USER_INPUT.EMAIL.TITLE}
+            errorMessage={USER_INPUT.EMAIL.ERROR_MESSAGE}
+            successMessage={USER_INPUT.EMAIL.SUCCESS_MESSAGE}
+            show={email && email.length > 0}
+            success={isEmailOk(email)}
+          />
+          <FormInput
+            name={USER_INPUT.NICKNAME.NAME}
+            placeholder={USER_INPUT.NICKNAME.PLACE_HOLDER}
+            title={USER_INPUT.NICKNAME.TITLE}
+            errorMessage={USER_INPUT.NICKNAME.ERROR_MESSAGE}
+            successMessage={USER_INPUT.NICKNAME.SUCCESS_MESSAGE}
+            show={nickname && nickname.length > 0}
+            success={nickname && isNicknameOk(nickname)}
+          />
+          <FormInput
+            name={USER_INPUT.PASSWORD.NAME}
+            type={USER_INPUT.PASSWORD.TYPE}
+            placeholder={USER_INPUT.PASSWORD.PLACE_HOLDER}
+            title={USER_INPUT.PASSWORD.TITLE}
+            errorMessage={USER_INPUT.PASSWORD.ERROR_MESSAGE}
+            successMessage={USER_INPUT.PASSWORD.SUCCESS_MESSAGE}
+            show={password && password.length > 0}
+            success={password && isPasswordOk(password)}
+          />
+          <FormInput
+            name={USER_INPUT.PASSWORD_CONFIRM.NAME}
+            type={USER_INPUT.PASSWORD_CONFIRM.TYPE}
+            placeholder={USER_INPUT.PASSWORD_CONFIRM.PLACE_HOLDER}
+            title={USER_INPUT.PASSWORD_CONFIRM.TITLE}
+            errorMessage={USER_INPUT.PASSWORD_CONFIRM.ERROR_MESSAGE}
+            successMessage={USER_INPUT.PASSWORD_CONFIRM.SUCCESS_MESSAGE}
+            show={passwordConfirm && passwordConfirm.length > 0}
+            success={passwordConfirm && password === passwordConfirm}
+          />
+          <ButtonContainer>
+            <Button
+              type='button'
+              label={BUTTON.LABEL.CANCEL}
+              width={125}
+              height={42}
+              bold={false}
+              dark={false}
+              handleClick={() => navigate('/')}
+            />
+            <Button
+              type='submit'
+              label={BUTTON.LABEL.SIGNUP}
+              width={125}
+              height={42}
+              bold={false}
+              dark={true}
+              handleClick={() => methods.handleSubmit(onSubmit)}
+            />
+          </ButtonContainer>
+        </SignUpFormContainer>
+      </FormProvider>
+    </>
+  );
+};
+
+export default SignUpForm;

--- a/src/pages/signup/components/index.ts
+++ b/src/pages/signup/components/index.ts
@@ -1,3 +1,4 @@
 import Logo from './Logo';
+import SignUpForm from './SignUpForm';
 
-export { Logo };
+export { Logo, SignUpForm };

--- a/src/pages/signup/constants/index.ts
+++ b/src/pages/signup/constants/index.ts
@@ -45,4 +45,11 @@ const MODAL = {
   }
 };
 
-export { USER_INPUT, MODAL };
+const BUTTON = {
+  LABEL: {
+    SIGNUP: '회원가입',
+    CANCEL: '취소'
+  }
+};
+
+export { USER_INPUT, MODAL, BUTTON };

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,3 +1,3 @@
-import SignUp from './signup';
+import SignUp from './SignUp';
 
 export default SignUp;

--- a/src/pages/signup/signup.style.ts
+++ b/src/pages/signup/signup.style.ts
@@ -9,7 +9,6 @@ export const SignUpForm = styled.form`
   width: 80%;
   min-width: 300px;
   max-width: 450px;
-  min-height: 400px;
   max-height: 600px;
   padding: 25px 20px;
   border-radius: 10px;

--- a/src/pages/signup/signup.tsx
+++ b/src/pages/signup/signup.tsx
@@ -1,147 +1,17 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useForm, FormProvider } from 'react-hook-form';
-import { Button } from '@components/Button';
-import { FormInput } from '@components/FormInput';
-import { Alert } from '@components/Alert';
-import {
-  SignUpValidations,
-  isEmailOk,
-  isNicknameOk,
-  isPasswordOk
-} from './validations';
-import postSignUpUser from '@apis/signup';
-import { MODAL, USER_INPUT, BUTTON } from './constants';
 import {
   LandingMain,
   HeadingContentContainer,
   Heading
 } from '@pages/landing/Landing.style';
-import { SignUpForm, ButtonContainer } from './signup.style';
-
-interface SignUpFormData {
-  email: string;
-  nickname: string;
-  password: string;
-  passwordConfirm: string;
-}
+import SignUpForm from './components/SignUpForm';
 
 const SignUp = () => {
-  const [emailErrorCatched, setEmailErrorCatched] = useState<boolean>(false);
-  const [signupSucceed, setSignupSucceed] = useState<boolean>(false);
-  const methods = useForm<SignUpFormData>();
-  const { watch } = methods;
-  const [email, nickname, password, passwordConfirm] = watch([
-    'email',
-    'nickname',
-    'password',
-    'passwordConfirm'
-  ]);
-
-  const navigate = useNavigate();
-
-  const onSubmit = () => {
-    if (SignUpValidations({ email, nickname, password, passwordConfirm })) {
-      postSignUpUser({
-        email,
-        password,
-        fullName: nickname
-      })
-        .then(() => {
-          setSignupSucceed(true);
-        })
-        .catch((error) => {
-          console.log(error);
-          setEmailErrorCatched(true);
-        });
-    }
-    setEmailErrorCatched(false);
-    return;
-  };
-
   return (
     <LandingMain>
       <HeadingContentContainer>
         <Heading />
       </HeadingContentContainer>
-
-      {emailErrorCatched && (
-        <Alert
-          emoji={MODAL.ERROR.EMOJI}
-          content={MODAL.ERROR.CONTENT}
-          buttonLabel={MODAL.ERROR.LABEL}
-        />
-      )}
-      {signupSucceed && (
-        <Alert
-          emoji={MODAL.SUCCESS.EMOJI}
-          content={MODAL.SUCCESS.CONTENT}
-          buttonLabel={MODAL.SUCCESS.LABEL}
-          nextPageLink='/login'
-        />
-      )}
-      <FormProvider {...methods}>
-        <SignUpForm onSubmit={methods.handleSubmit(onSubmit)}>
-          <FormInput
-            name={USER_INPUT.EMAIL.NAME}
-            placeholder={USER_INPUT.EMAIL.PLACE_HOLDER}
-            title={USER_INPUT.EMAIL.TITLE}
-            errorMessage={USER_INPUT.EMAIL.ERROR_MESSAGE}
-            successMessage={USER_INPUT.EMAIL.SUCCESS_MESSAGE}
-            show={email && email.length > 0}
-            success={isEmailOk(email)}
-          />
-          <FormInput
-            name={USER_INPUT.NICKNAME.NAME}
-            placeholder={USER_INPUT.NICKNAME.PLACE_HOLDER}
-            title={USER_INPUT.NICKNAME.TITLE}
-            errorMessage={USER_INPUT.NICKNAME.ERROR_MESSAGE}
-            successMessage={USER_INPUT.NICKNAME.SUCCESS_MESSAGE}
-            show={nickname && nickname.length > 0}
-            success={nickname && isNicknameOk(nickname)}
-          />
-          <FormInput
-            name={USER_INPUT.PASSWORD.NAME}
-            type={USER_INPUT.PASSWORD.TYPE}
-            placeholder={USER_INPUT.PASSWORD.PLACE_HOLDER}
-            title={USER_INPUT.PASSWORD.TITLE}
-            errorMessage={USER_INPUT.PASSWORD.ERROR_MESSAGE}
-            successMessage={USER_INPUT.PASSWORD.SUCCESS_MESSAGE}
-            show={password && password.length > 0}
-            success={password && isPasswordOk(password)}
-          />
-          <FormInput
-            name={USER_INPUT.PASSWORD_CONFIRM.NAME}
-            type={USER_INPUT.PASSWORD_CONFIRM.TYPE}
-            placeholder={USER_INPUT.PASSWORD_CONFIRM.PLACE_HOLDER}
-            title={USER_INPUT.PASSWORD_CONFIRM.TITLE}
-            errorMessage={USER_INPUT.PASSWORD_CONFIRM.ERROR_MESSAGE}
-            successMessage={USER_INPUT.PASSWORD_CONFIRM.SUCCESS_MESSAGE}
-            show={passwordConfirm && passwordConfirm.length > 0}
-            success={passwordConfirm && password === passwordConfirm}
-          />
-          <ButtonContainer>
-            <Button
-              type='button'
-              label={BUTTON.LABEL.CANCEL}
-              width={125}
-              height={42}
-              bold={false}
-              dark={false}
-              handleClick={() => navigate('/')}
-            />
-            <Button
-              type='submit'
-              label={BUTTON.LABEL.SIGNUP}
-              width={125}
-              height={42}
-              bold={false}
-              dark={true}
-              handleClick={() => methods.handleSubmit(onSubmit)}
-            />
-          </ButtonContainer>
-        </SignUpForm>
-      </FormProvider>
+      <SignUpForm />
     </LandingMain>
   );
 };

--- a/src/pages/signup/signup.tsx
+++ b/src/pages/signup/signup.tsx
@@ -143,6 +143,7 @@ const SignUp = () => {
         />
         <ButtonContainer>
           <Button
+            type='button'
             label='취소'
             width={125}
             height={42}
@@ -151,6 +152,7 @@ const SignUp = () => {
             handleClick={() => navigate('/')}
           />
           <Button
+            type='submit'
             label='회원가입'
             width={125}
             height={42}

--- a/src/pages/signup/validations/index.ts
+++ b/src/pages/signup/validations/index.ts
@@ -1,12 +1,19 @@
-export const isEmailOk = (email: string) => {
+interface SignUpValidationProps {
+  email: string;
+  nickname: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+const isEmailOk = (email: string) => {
   return new RegExp('[a-z0-9]+@[a-z]+\\.[a-z]{2,3}').test(email);
 };
 
-export const isNicknameOk = (nickname: string) => {
+const isNicknameOk = (nickname: string) => {
   return nickname.length >= 1 && nickname.length <= 8;
 };
 
-export const isPasswordOk = (password: string) => {
+const isPasswordOk = (password: string) => {
   const lengthOk =
     !password.includes(' ') && password.length >= 8 && password.length <= 32;
   const containsAlphabet = /[a-zA-Z]/.test(password);
@@ -18,3 +25,30 @@ export const isPasswordOk = (password: string) => {
     ).length >= 2;
   return lengthOk && containsOk;
 };
+
+const SignUpValidations = ({
+  email,
+  nickname,
+  password,
+  passwordConfirm
+}: SignUpValidationProps) => {
+  if (!isEmailOk(email)) {
+    return false;
+  }
+
+  if (!isNicknameOk(nickname)) {
+    return false;
+  }
+
+  if (!isPasswordOk(password)) {
+    return false;
+  }
+
+  if (password !== passwordConfirm) {
+    return false;
+  }
+
+  return true;
+};
+
+export { SignUpValidations, isEmailOk, isNicknameOk, isPasswordOk };


### PR DESCRIPTION
## 🪄 변경사항
### react-hook-form을 사용해서 form 제출 로직을 변경했습니다.
- SignUp 페이지 파일에서는 랜더링에만 관여하게 만들었습니다.
- Form 제출 관련 로직을 페이지 파일에서 분리했습니다.
- Button 컴포넌트에 type을 props로 받을 수 있게 변경했습니다.
- SignUp, Login, Password-update 에서 UserInput 컴포넌트를 사용했었는데 FormInput으로 분리해서 사용하게 변경했습니다.

## ✏️ PR 포인트
PR이 길어져서 더 수정할 사항은 새로 PR만들어서 제출하겠습니다.
코드가 조금 줄긴했지만 react-hook-form을 더 잘 사용할 수 있을 방법이 있을거 같습니다.

## 추가 예정
- react-hook-form 기능 더 잘 활용하기 (error, validation...)
- Login, Password 페이지도 랜더링만 관여하게 수정하기