### PR TITLE
🚨 Fix: 포스트 페이지에서 테마를 바꾸면 데이터 페칭이 한번 더 일어나는 현상 개선

### DIFF
--- a/src/pages/posts/utils/editPostData.ts
+++ b/src/pages/posts/utils/editPostData.ts
@@ -1,28 +1,30 @@
-import type { EditedPost, Post } from '@/types';
+import type { EditedPost, Post, RawTitleData } from '@/types';
 
 const editTimeForm = (time: string) => {
   return time.split('T')[0].split('-').join('.');
 };
 
-const splitTitleData = (title: string) => {
-  const splitData = JSON.parse(title);
+const splitTitleData = (rawTitle: string) => {
+  const { content, meditationTime } = JSON.parse(rawTitle) as RawTitleData;
 
-  return [splitData.title, splitData.meditationTime];
+  return { content, meditationTime };
 };
 
 const editPostData = (posts: Post[]): EditedPost[] => {
   if (!posts) {
     return [];
   }
-  const editedData = posts.map((post: Post) => {
+  return posts.map((post: Post) => {
     post.createdAt = editTimeForm(post.createdAt);
     post.updatedAt = editTimeForm(post.updatedAt);
-    const [content, meditationTime] = splitTitleData(post.title);
+    const { content, meditationTime } = splitTitleData(post.title);
+
+    if (content.length === 0) {
+      return { ...post, content: '내용이 없습니다.', meditationTime };
+    }
 
     return { ...post, content, meditationTime };
   });
-
-  return editedData;
 };
 
 export { editPostData };

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -26,3 +26,8 @@ type OmitPost = Omit<Post, 'author'>;
 export interface SearchEditedPost extends OmitPost {
   author: string;
 }
+
+export type RawTitleData = {
+  content: string;
+  meditationTime: number;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import type { Comment } from './Comment';
 import type { Like } from './Like';
 import type { User } from './User';
 import type { Conversation } from './Conversation';
-import type { EditedPost, Post, SearchEditedPost } from './Post';
+import type { EditedPost, Post, SearchEditedPost, RawTitleData } from './Post';
 import type { Follow } from './Follow';
 import type { Notification } from './Notification';
 import type { Channel } from './Channel';
@@ -15,6 +15,7 @@ export type {
   Conversation,
   Post,
   EditedPost,
+  RawTitleData,
   SearchEditedPost,
   Follow,
   Notification,


### PR DESCRIPTION
오랜만입니다 여러분!

## 🪄 변경사항
![Dec-14-2023 10-02-40](https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/69716992/caea05d6-d555-4c25-8c30-6dc791c15a32)

포스트 페이지에서 테마를 바꾸면 위와 같이 이전 데이터가 살짝 보였다가 변경된 테마에 대한 데이터가 페칭되는 동작이 있었는데요..
이게 뭔가 부자연스러운 동작같아서 고쳐보았습니다..

원인은 내용이 없는 명상 기록 때문이었습니다!

명상 기록이 없는 포스트 데이터의 경우 처음에 offset=0으로 해서 데이터를 10개씩 가져와도 실제 클라이언트가 갖고있는 데이터의 개수에 포함이 안됐고, 그래서 아래 코드가 동작하면서 데이터 페칭이 이루어졌던 것입니다 ㅎㅎ
```ts
  useEffect(() => {
    if (postsRef.current && data.length >= 10) {
      const { lastChild } = postsRef.current;
      lastChild && observe(lastChild);
    }
  }, [postsData]);
```

그래서 제대로 포스트 개수를 인식하도록 처음에 명상 기록과 시간 데이터를 파싱하는 단계에서 기록이 없는 경우 대체되는 내용을 삽입하도록 변경하였습니다!

```ts
const editPostData = (posts: Post[]): EditedPost[] => {
  if (!posts) {
    return [];
  }
  return posts.map((post: Post) => {
    post.createdAt = editTimeForm(post.createdAt);
    post.updatedAt = editTimeForm(post.updatedAt);
    const { content, meditationTime } = splitTitleData(post.title);

    if (content.length === 0) {
      return { ...post, content: '내용이 없습니다.', meditationTime };
    }

    return { ...post, content, meditationTime };
  });
};
```

와중에 content가 any로 추론되고 있어서 타입도 하나 추가했습니다 ㅎㅎ

## 🖥 결과 화면

![Dec-14-2023 10-02-52](https://github.com/prgrms-fe-devcourse/FEDC4_NIRVANA_Gidong/assets/69716992/b05ef937-efb9-4831-b45c-a20d0f17a08b)


## ✏️ PR 포인트

명상 기록이 있는 포스트가 10개 채워지도록 데이터를 모은 뒤에 보여주는 동작도 생각해보긴 했는데 초기 로딩 시간이 너무 오래 걸릴 것 같아서 포기했습니다. 더 좋은 방법 있으면 제안 부탁드려요!

아 그리고 이상하게 집중 -> 불안으로 바꿀 때는 조금 느린데, 불안 -> 자유 이렇게 갈 때는 페칭 속도가 빠르더라고요..? 이것도 개선 가능한지 알아보겠습니닷
